### PR TITLE
update GoogleUtilities to 6.4.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -108,7 +108,7 @@
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="~> 4.4.0"/>
-        <pod name="GoogleUtilities" spec="~> 6.3.0"/>
+        <pod name="GoogleUtilities" spec="~> 6.4.0"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
Solving conflicting GoogleUtilities with cordova-plugin-firebasex:

```
[!] CocoaPods could not find compatible versions for pod "GoogleUtilities/ISASwizzler":
  In snapshot (Podfile.lock):
    GoogleUtilities/ISASwizzler (= 6.4.0, ~> 6.2)

  In Podfile:
 
   Firebase/Performance (= 6.11.0) was resolved to 6.11.0, which depends on
      FirebasePerformance (~> 3.1.5) was resolved to 3.1.6, which depends on
        GoogleUtilities/ISASwizzler (~> 6.2)
```
